### PR TITLE
Implement GCD PoC

### DIFF
--- a/gcd/api/app.py
+++ b/gcd/api/app.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from ..models.inference import generate
+from ..models.performance import metrics
+from ..services.execution import execute
+from ..models.loader import load_model
+
+app = FastAPI()
+
+class AskRequest(BaseModel):
+    question: str
+
+@app.on_event("startup")
+async def startup_event():
+    load_model()
+
+@app.post("/ask")
+async def ask(req: AskRequest):
+    result = await generate(req.question)
+    return execute(result)
+
+@app.get("/metrics")
+async def get_metrics():
+    return metrics()
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/gcd/config.py
+++ b/gcd/config.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    model_path: Path = Path("models/ggml-model.bin")
+    n_ctx: int = 2048
+    n_threads: int = 4
+    log_level: str = "INFO"
+
+settings = Settings()

--- a/gcd/demo.py
+++ b/gcd/demo.py
@@ -1,0 +1,4 @@
+from gcd.api.app import app
+
+# This file is a placeholder for running the FastAPI app with uvicorn
+# Example: `uvicorn gcd.api.app:app`

--- a/gcd/grammar/base.py
+++ b/gcd/grammar/base.py
@@ -1,0 +1,9 @@
+BASE_TYPES = {
+    "string": r'<string> ::= "(?:\\\\.|[^\\\\"])*"',
+    "int": r"<int> ::= -?[0-9]+",
+    "float": r"<float> ::= -?[0-9]+(?:\\.[0-9]+)?",
+    "bool": r"<bool> ::= \"True\" | \"False\"",
+}
+
+def base_grammar() -> str:
+    return "\n".join(BASE_TYPES.values())

--- a/gcd/grammar/generator.py
+++ b/gcd/grammar/generator.py
@@ -1,0 +1,46 @@
+from inspect import signature, Parameter
+from typing import List
+
+from ..tools.metadata import ToolMetadata
+from .base import base_grammar, BASE_TYPES
+
+TYPE_MAP = {
+    str: "<string>",
+    int: "<int>",
+    float: "<float>",
+    bool: "<bool>",
+}
+
+
+def rule_from_signature(meta: ToolMetadata) -> str:
+    sig = signature(meta.function)
+    parts: List[str] = []
+    for i, param in enumerate(sig.parameters.values()):
+        type_rule = TYPE_MAP.get(param.annotation, "<string>")
+        if param.default is not Parameter.empty:
+            part = f"[ {type_rule} ]"
+        else:
+            part = type_rule
+        if i > 0:
+            parts.append('", "')
+        parts.append(part)
+    args = " ".join(parts)
+    return f"<{meta.name}> ::= \"{meta.name}(\" {args} \")\""
+
+
+def generate_tool_rules(metas: List[ToolMetadata]) -> List[str]:
+    rules = []
+    for meta in metas:
+        if meta.custom_grammar:
+            rules.append(meta.custom_grammar)
+        else:
+            rules.append(rule_from_signature(meta))
+    return rules
+
+
+def combine_grammar(metas: List[ToolMetadata]) -> str:
+    rules = generate_tool_rules(metas)
+    root_alts = [f"<{m.name}>" for m in metas]
+    rules.append(f"<root> ::= {' | '.join(root_alts)}")
+    rules.append(base_grammar())
+    return "\n".join(rules)

--- a/gcd/logging_config.py
+++ b/gcd/logging_config.py
@@ -1,0 +1,9 @@
+import logging
+from .config import settings
+
+logging.basicConfig(
+    level=getattr(logging, settings.log_level),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+logger = logging.getLogger("gcd")

--- a/gcd/models/concurrency.py
+++ b/gcd/models/concurrency.py
@@ -1,0 +1,9 @@
+import asyncio
+
+_model_lock = asyncio.Lock()
+
+async def run_with_lock(coro, timeout: float | None = None):
+    async with _model_lock:
+        if timeout:
+            return await asyncio.wait_for(coro, timeout)
+        return await coro

--- a/gcd/models/inference.py
+++ b/gcd/models/inference.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from ..tools.registry import registry
+from .loader import load_model
+from .prompt import build_system_prompt
+from .concurrency import run_with_lock
+from .performance import increment_requests
+
+async def generate(question: str, max_tokens: int = 64, timeout: Optional[float] = None) -> str:
+    model = load_model()
+    increment_requests()
+    if model is None:
+        return ""
+    metas = list(registry.all_tools().values())
+    system_prompt = build_system_prompt(metas)
+    prompt = system_prompt + "\n" + question
+
+    async def _call():
+        return await model(prompt, max_tokens=max_tokens, temperature=0.0)
+
+    return await run_with_lock(_call(), timeout=timeout)

--- a/gcd/models/loader.py
+++ b/gcd/models/loader.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Optional
+
+try:
+    from llama_cpp import Llama, LlamaGrammar
+except ImportError:  # pragma: no cover - allow running without package
+    Llama = None
+    LlamaGrammar = None
+
+from ..logging_config import logger
+from ..grammar.generator import combine_grammar
+from ..tools.registry import registry
+from ..config import settings
+
+_model = None
+_grammar = None
+
+def load_grammar() -> Optional[str]:
+    global _grammar
+    if _grammar is None:
+        metas = list(registry.all_tools().values())
+        _grammar = combine_grammar(metas)
+    return _grammar
+
+
+def load_model(model_path: Optional[Path] = None):
+    global _model
+    if _model is not None:
+        return _model
+    model_path = model_path or settings.model_path
+    if not model_path.exists():
+        raise FileNotFoundError(f"Model not found at {model_path}")
+    if Llama is None:
+        logger.warning("llama_cpp not installed; using mock")
+        _model = None
+    else:
+        grammar_text = load_grammar()
+        llm_kwargs = {"model_path": str(model_path), "n_ctx": settings.n_ctx, "n_threads": settings.n_threads}
+        if grammar_text:
+            grammar = LlamaGrammar.from_string(grammar_text)
+            llm_kwargs["grammar"] = grammar
+        _model = Llama(**llm_kwargs)
+    return _model

--- a/gcd/models/performance.py
+++ b/gcd/models/performance.py
@@ -1,0 +1,13 @@
+import psutil
+
+_request_count = 0
+
+def increment_requests() -> None:
+    global _request_count
+    _request_count += 1
+
+def metrics() -> dict:
+    return {
+        "requests": _request_count,
+        "memory": psutil.Process().memory_info().rss,
+    }

--- a/gcd/models/prompt.py
+++ b/gcd/models/prompt.py
@@ -1,0 +1,14 @@
+from typing import List
+from ..tools.metadata import ToolMetadata
+
+SYSTEM_TEMPLATE = "Available tools:\n{tools}\nRespond with a tool call."
+
+
+def tool_description(meta: ToolMetadata) -> str:
+    params = meta.signature
+    return f"- {meta.name}{params}: {meta.description}"
+
+
+def build_system_prompt(metas: List[ToolMetadata]) -> str:
+    desc = "\n".join(tool_description(m) for m in metas)
+    return SYSTEM_TEMPLATE.format(tools=desc)

--- a/gcd/services/errors.py
+++ b/gcd/services/errors.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class ErrorResponse(BaseModel):
+    error: str

--- a/gcd/services/execution.py
+++ b/gcd/services/execution.py
@@ -1,0 +1,25 @@
+from .errors import ErrorResponse
+import json
+import time
+from typing import Any
+
+from ..logging_config import logger
+from .validation import validate_call
+from .parser import parse_output
+
+
+def execute(text: str) -> str:
+    start = time.time()
+    try:
+        call = parse_output(text)
+    except Exception as e:
+        logger.error("parse fail", exc_info=e)
+        return json.dumps(ErrorResponse(error="parse_error").dict())
+    try:
+        result = validate_call(call)
+        duration = time.time() - start
+        response = {"result": result, "time": duration}
+    except Exception as e:
+        logger.error("execution error", exc_info=e)
+        response = ErrorResponse(error=str(e)).dict()
+    return json.dumps(response)

--- a/gcd/services/parser.py
+++ b/gcd/services/parser.py
@@ -1,0 +1,24 @@
+import ast
+from typing import Any, List
+
+from pydantic import BaseModel, ValidationError
+
+from ..tools.registry import registry
+
+class ParsedCall(BaseModel):
+    name: str
+    args: List[Any]
+
+
+def parse_output(text: str) -> ParsedCall:
+    try:
+        node = ast.parse(text.strip(), mode="eval")
+    except SyntaxError as e:
+        raise ValueError("invalid syntax") from e
+    if not isinstance(node.body, ast.Call):
+        raise ValueError("expected single function call")
+    func_name = getattr(node.body.func, 'id', None)
+    if func_name is None:
+        raise ValueError("invalid function name")
+    args = [ast.literal_eval(arg) for arg in node.body.args]
+    return ParsedCall(name=func_name, args=args)

--- a/gcd/services/validation.py
+++ b/gcd/services/validation.py
@@ -1,0 +1,29 @@
+from inspect import signature
+from typing import Any, get_type_hints
+
+from pydantic import BaseModel
+
+from ..tools.registry import registry
+from .parser import ParsedCall
+
+
+def validate_call(call: ParsedCall) -> Any:
+    if call.name not in registry.all_tools():
+        raise ValueError("unknown tool")
+    tool_meta = registry.get(call.name)
+    func = tool_meta.function
+    sig = signature(func)
+    hints = get_type_hints(func)
+    if len(call.args) != len(sig.parameters):
+        raise ValueError("argument count mismatch")
+    validated_args = []
+    for arg, (name, param) in zip(call.args, sig.parameters.items()):
+        expected = hints.get(name, str)
+        try:
+            if isinstance(expected, type) and issubclass(expected, BaseModel):
+                validated_args.append(expected.parse_obj(arg))
+            else:
+                validated_args.append(expected(arg))
+        except Exception as e:
+            raise ValueError(f"type error for {name}") from e
+    return func(*validated_args)

--- a/gcd/tests/test_api.py
+++ b/gcd/tests/test_api.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from gcd.api.app import app
+
+client = TestClient(app)
+
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.json()["status"] == "ok"
+
+
+def test_metrics():
+    resp = client.get("/metrics")
+    assert "requests" in resp.json()

--- a/gcd/tests/test_concurrency.py
+++ b/gcd/tests/test_concurrency.py
@@ -1,0 +1,18 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gcd.models.inference import generate
+from gcd.models.concurrency import _model_lock
+
+@pytest.mark.asyncio
+async def test_run_with_lock():
+    mock_model = AsyncMock(return_value='ok')
+    with patch('gcd.models.inference.load_model', return_value=mock_model), \
+         patch('gcd.models.inference.build_system_prompt', return_value='prompt'), \
+         patch('gcd.models.inference.registry') as reg:
+        reg.all_tools.return_value = {}
+        result = await generate('hi')
+        result = await generate("hi", timeout=0.1)
+    assert _model_lock.locked() is False

--- a/gcd/tests/test_dynamic.py
+++ b/gcd/tests/test_dynamic.py
@@ -1,0 +1,12 @@
+from gcd.tools.registry import register_tool, regenerate_grammar
+
+
+def sample_tool(x: int) -> int:
+    """A sample"""
+    return x
+
+
+def test_dynamic_registration():
+    register_tool(sample_tool)
+    grammar = regenerate_grammar()
+    assert '<sample_tool>' in grammar

--- a/gcd/tests/test_errors.py
+++ b/gcd/tests/test_errors.py
@@ -1,0 +1,14 @@
+from gcd.services.execution import execute
+from gcd.services.errors import ErrorResponse
+
+
+def test_parse_fail():
+    out = execute("not a call")
+    data = ErrorResponse.parse_raw(out)
+    assert data.error == "parse_error"
+
+
+def test_error_response():
+    out = execute('bad(')
+    data = ErrorResponse.parse_raw(out)
+    assert data.error

--- a/gcd/tests/test_execution.py
+++ b/gcd/tests/test_execution.py
@@ -1,0 +1,12 @@
+from gcd.services.execution import execute
+from gcd.tests.test_parsing import multiply
+
+
+def test_execute_success():
+    output = execute('multiply(2, 5)')
+    assert 'result' in output
+
+
+def test_execute_error():
+    out = execute('unknown(1)')
+    assert 'error' in out

--- a/gcd/tests/test_grammar.py
+++ b/gcd/tests/test_grammar.py
@@ -1,0 +1,15 @@
+from gcd.tools.registry import registry, tool
+from gcd.grammar.generator import combine_grammar
+
+@tool
+def add(x: int, y: int) -> int:
+    """Add numbers"""
+    return x + y
+
+
+def test_combine_grammar():
+    metas = list(registry.all_tools().values())
+    grammar = combine_grammar(metas)
+    assert '<root>' in grammar
+    assert '<add>' in grammar
+    assert '<int>' in grammar

--- a/gcd/tests/test_metadata.py
+++ b/gcd/tests/test_metadata.py
@@ -1,0 +1,24 @@
+from gcd.tools.metadata import extract_tool_metadata
+from gcd.tools.registry import registry, tool
+
+@tool
+def sample(a: int, b: str = "x") -> str:
+    """Example tool.
+
+    Grammar:
+        <call> ::= "sample(" <int> ", " <string> ")"
+    """
+    return b * a
+
+
+def test_extract_tool_metadata():
+    meta = extract_tool_metadata(sample)
+    assert meta.name == "sample"
+    assert "Example tool" in meta.description
+    assert "a" in meta.signature
+    assert meta.custom_grammar is not None
+
+
+def test_registry():
+    reg_meta = registry.get("sample")
+    assert reg_meta.name == "sample"

--- a/gcd/tests/test_model.py
+++ b/gcd/tests/test_model.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from gcd.models.loader import load_model, load_grammar
+from gcd.tools.registry import tool
+
+@tool
+def dummy(a: int) -> int:
+    """Dummy tool"""
+    return a
+
+
+def test_load_grammar():
+    gram = load_grammar()
+    assert '<root>' in gram
+
+
+def test_load_model(tmp_path):
+    model_file = tmp_path / "model.bin"
+    model_file.write_text("dummy")
+    with patch('gcd.models.loader.Llama') as MockLlama, patch('gcd.models.loader.LlamaGrammar') as MockGrammar:
+        load_model(model_file)
+        assert MockLlama.called

--- a/gcd/tests/test_parsing.py
+++ b/gcd/tests/test_parsing.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+
+from gcd.services.parser import parse_output
+from gcd.services.validation import validate_call
+from gcd.tools.registry import tool
+
+@tool
+def multiply(x: int, y: int) -> int:
+    """Multiply"""
+    return x * y
+
+class Item(BaseModel):
+    name: str
+
+@tool
+def echo(item: Item) -> str:
+    """Echo"""
+    return item.name
+
+
+def test_parse_output():
+    call = parse_output('multiply(2, 3)')
+    assert call.name == 'multiply'
+    assert call.args == [2, 3]
+
+
+def test_validate_call_simple():
+    call = parse_output('multiply(2, 4)')
+    result = validate_call(call)
+    assert result == 8
+
+
+def test_validate_call_pydantic():
+    call = parse_output("echo({'name': 'hi'})")
+    result = validate_call(call)
+    assert result == 'hi'

--- a/gcd/tests/test_performance.py
+++ b/gcd/tests/test_performance.py
@@ -1,0 +1,9 @@
+from gcd.models.performance import metrics, increment_requests
+
+
+def test_metrics():
+    before = metrics()['requests']
+    increment_requests()
+    after = metrics()['requests']
+    assert after == before + 1
+    assert 'memory' in metrics()

--- a/gcd/tests/test_sample_tool.py
+++ b/gcd/tests/test_sample_tool.py
@@ -1,0 +1,5 @@
+from gcd.tools.sample import add
+
+
+def test_add():
+    assert add(2, 3) == 5

--- a/gcd/tools/metadata.py
+++ b/gcd/tools/metadata.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from inspect import signature
+from typing import Callable, Dict, Optional
+
+from docstring_parser import parse
+
+@dataclass
+class ToolMetadata:
+    name: str
+    description: str
+    function: Callable
+    signature: str
+    custom_grammar: Optional[str]
+
+def extract_tool_metadata(func: Callable) -> ToolMetadata:
+    sig = signature(func)
+    doc = func.__doc__ or ""
+    parsed = parse(doc)
+    description = parsed.short_description or ""
+    custom_grammar = None
+    if parsed.long_description:
+        lines = [line.rstrip() for line in parsed.long_description.splitlines()]
+        grammar_lines = []
+        in_grammar = False
+        for line in lines:
+            if line.strip().lower().startswith("grammar:"):
+                in_grammar = True
+                continue
+            if in_grammar:
+                grammar_lines.append(line)
+        if grammar_lines:
+            custom_grammar = "\n".join(grammar_lines).strip() or None
+    return ToolMetadata(
+        name=func.__name__,
+        description=description,
+        function=func,
+        signature=str(sig),
+        custom_grammar=custom_grammar,
+    )

--- a/gcd/tools/registry.py
+++ b/gcd/tools/registry.py
@@ -1,0 +1,37 @@
+from typing import Callable, Dict
+from inspect import signature
+
+from .metadata import ToolMetadata, extract_tool_metadata
+
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: Dict[str, ToolMetadata] = {}
+
+    def register(self, func: Callable) -> Callable:
+        meta = extract_tool_metadata(func)
+        # Validate function has type hints for all parameters
+        sig = signature(func)
+        for name, param in sig.parameters.items():
+            if param.annotation is param.empty:
+                raise TypeError(f"Parameter '{name}' missing type annotation")
+        self._tools[meta.name] = meta
+        return func
+
+    def get(self, name: str) -> ToolMetadata:
+        return self._tools[name]
+
+    def all_tools(self) -> Dict[str, ToolMetadata]:
+        return dict(self._tools)
+registry = ToolRegistry()
+
+def tool(func: Callable) -> Callable:
+    registry.register(func)
+    return func
+
+def register_tool(func: Callable) -> Callable:
+    return registry.register(func)
+
+def regenerate_grammar() -> str:
+    from ..grammar.generator import combine_grammar
+    metas = list(registry.all_tools().values())
+    return combine_grammar(metas)

--- a/gcd/tools/sample.py
+++ b/gcd/tools/sample.py
@@ -1,0 +1,6 @@
+from .registry import tool
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    return a + b

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+llama-cpp-python
+fastapi
+uvicorn
+pydantic
+docstring_parser
+pytest
+pytest-asyncio
+psutil


### PR DESCRIPTION
## Summary
- set up project structure with dependencies
- implement tool registry and metadata extraction
- build GBNF grammar generator
- integrate model loading, prompts and inference
- add AST parsing and validation with pydantic support
- implement safe execution wrapper and concurrency
- expose FastAPI endpoints and sample tool
- provide comprehensive unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888077257fc83259f26c8c50b5993b9